### PR TITLE
Corrected event name for profileTwo

### DIFF
--- a/experimental/puppets/js/app.controller.js
+++ b/experimental/puppets/js/app.controller.js
@@ -20,7 +20,7 @@ app.addInitializer(function(){
   });
 
   // Command the app to render the second profile
-  globalCh.commands.setHandler( 'render:profileOne', function(profileView) {
+  globalCh.commands.setHandler( 'render:profileTwo', function(profileView) {
     app.getRegion( 'profileTwoRegion' ).show( profileView );
   });
 


### PR DESCRIPTION
James, looks like the second event name needed to be updated from `render:profileOne` to `render:profileTwo`.
